### PR TITLE
Aggiunta dialoghi di stato dei quiz

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
 		"**/node_modules": true, // Hide "node_modules"
 		"**/StrumentalMente-*-x*": true // Hide build directories
 	},
-	"html.format.wrapAttributes": "aligned-multiple",
+	"html.format.wrapAttributes": "force-aligned",
 	"html.format.wrapLineLength": 0,
 	"scssFormatter.useTabs": true,
 	"scssFormatter.tabWidth": 4

--- a/src/assets/css/main/cards.css
+++ b/src/assets/css/main/cards.css
@@ -64,6 +64,8 @@
 }
 
 .card-horizontal-alt {
+	border: none;
+    padding: 0;
 	display: flex;
 	position: relative;
 	margin: 0.5rem auto 1rem auto;
@@ -72,6 +74,10 @@
 	border-radius: 2px;
 	box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12), 0 1px 5px 0 rgba(0, 0, 0, 0.2);
 	max-width: 350px;
+}
+
+button.card-horizontal-alt{
+	cursor: pointer;
 }
 
 .card-horizontal .card-image {

--- a/src/assets/js/render.js
+++ b/src/assets/js/render.js
@@ -325,9 +325,9 @@ window.addEventListener("load", () => {
 		Mousetrap.bind("alt+s shift+b", () => { warnIfIncomplete('base', 'teoria base', 'agli strumenti', () => { remote.getCurrentWindow().loadFile("./teoria-batteria.html"); }); });
 		Mousetrap.bind("alt+s p", () => { warnIfIncomplete('base', 'teoria base', 'agli strumenti', () => { remote.getCurrentWindow().loadFile("./teoria-piano.html"); }); });
 		Mousetrap.bind("alt+a a", () => { remote.getCurrentWindow().loadFile("./home-accordi.html"); });
-		Mousetrap.bind("alt+a c", () => { remote.getCurrentWindow().loadFile("./accordi-chitarra.html"); });
-		Mousetrap.bind("alt+a b", () => { remote.getCurrentWindow().loadFile("./accordi-basso.html"); });
-		Mousetrap.bind("alt+a p", () => { remote.getCurrentWindow().loadFile("./accordi-piano.html"); });
+		Mousetrap.bind("alt+a c", () => { warnIfIncomplete('chitarra', 'teoria della chitarra', 'agli accordi della chitarra', () => { remote.getCurrentWindow().loadFile("./accordi-chitarra.html"); }); });
+		Mousetrap.bind("alt+a b", () => { warnIfIncomplete('basso', 'teoria del basso', 'agli accordi del basso', () => { remote.getCurrentWindow().loadFile("./accordi-basso.html"); }); });
+		Mousetrap.bind("alt+a p", () => { warnIfIncomplete('piano', 'teoria del pianoforte', 'agli accordi del pianoforte', () => { remote.getCurrentWindow().loadFile("./accordi-piano.html"); }); });
 		Mousetrap.bind("alt+p", () => { remote.getCurrentWindow().loadFile("./profile.html"); });
 		Mousetrap.bind("alt+m", () => { openModal("./map.html"); });
 		Mousetrap.bind("alt+i", () => { openModal("./about.html"); });

--- a/src/assets/js/render.js
+++ b/src/assets/js/render.js
@@ -10,6 +10,28 @@
 
 const remote = require('electron').remote; // Riferimento a Electron
 
+function warnIfIncomplete(previousQuizId, previousQuizName, topicToOpenName, callback) {
+	const { ipcRenderer } = require("electron");
+	var result = ipcRenderer.sendSync("get-quiz", previousQuizId);
+	if (!result) {
+		let hasBeenAsked = JSON.parse(sessionStorage.getItem(`${topicToOpenName}-notdone-asked`));
+		sessionStorage.setItem(`${topicToOpenName}-notdone-asked`, "true");
+
+		var answer = hasBeenAsked || ipcRenderer.sendSync("prompt", {
+			title: "Attenzione!",
+			label: `Hai scelto di proseguire <em>${topicToOpenName}</em> senza aver completato il quiz di <em>${previousQuizName}</em>! Sei sicuro di voler continuare?`,
+			yes: "Sì",
+			yesReturn: true,
+			no: "No",
+			noReturn: false,
+			file: "./dialogs/exit-dialog.html"
+		});
+
+		if (answer)
+			callback();
+	}
+}
+
 /**
  * Gestisce gli eventi della titlebar.
  * 

--- a/src/assets/js/render.js
+++ b/src/assets/js/render.js
@@ -320,10 +320,10 @@ window.addEventListener("load", () => {
 		Mousetrap.bind("alt+h", () => { remote.getCurrentWindow().loadFile("./home.html"); });
 		Mousetrap.bind("alt+t", () => { remote.getCurrentWindow().loadFile("./home-teoria.html"); });
 		Mousetrap.bind("alt+s s", () => { remote.getCurrentWindow().loadFile("./home-strumenti.html"); });
-		Mousetrap.bind("alt+s c", () => { remote.getCurrentWindow().loadFile("./teoria-chitarra.html"); });
-		Mousetrap.bind("alt+s b", () => { remote.getCurrentWindow().loadFile("./teoria-basso.html"); });
-		Mousetrap.bind("alt+s shift+b", () => { remote.getCurrentWindow().loadFile("./teoria-batteria.html"); });
-		Mousetrap.bind("alt+s p", () => { remote.getCurrentWindow().loadFile("./teoria-piano.html"); });
+		Mousetrap.bind("alt+s c", () => { warnIfIncomplete('base', 'teoria base', 'agli strumenti', () => { remote.getCurrentWindow().loadFile("./teoria-chitarra.html"); }); });
+		Mousetrap.bind("alt+s b", () => { warnIfIncomplete('base', 'teoria base', 'agli strumenti', () => { remote.getCurrentWindow().loadFile("./teoria-basso.html"); }); });
+		Mousetrap.bind("alt+s shift+b", () => { warnIfIncomplete('base', 'teoria base', 'agli strumenti', () => { remote.getCurrentWindow().loadFile("./teoria-batteria.html"); }); });
+		Mousetrap.bind("alt+s p", () => { warnIfIncomplete('base', 'teoria base', 'agli strumenti', () => { remote.getCurrentWindow().loadFile("./teoria-piano.html"); }); });
 		Mousetrap.bind("alt+a a", () => { remote.getCurrentWindow().loadFile("./home-accordi.html"); });
 		Mousetrap.bind("alt+a c", () => { remote.getCurrentWindow().loadFile("./accordi-chitarra.html"); });
 		Mousetrap.bind("alt+a b", () => { remote.getCurrentWindow().loadFile("./accordi-basso.html"); });

--- a/src/assets/js/render.js
+++ b/src/assets/js/render.js
@@ -10,6 +10,17 @@
 
 const remote = require('electron').remote; // Riferimento a Electron
 
+/**
+ * Mostra un messaggio all'utente se il quiz propedeutico all'argomento scelto
+ * non è stato completato. Se l'utente conferma di voler proseguire, viene
+ * effettuata l'azione richiesta, altrimenti non si attua alcuna azione.
+ *
+ * @param {String} previousQuizId L'id del quiz propedeutico
+ * @param {String} previousQuizName Il nome del quiz (da comunicare all'utente)
+ * @param {String} topicToOpenName Il nome dell'argomento che si vuole aprire
+ * @param {*} callback La funzione da eseguire se l'utente accetta di
+ * proseguire.
+ */
 function warnIfIncomplete(previousQuizId, previousQuizName, topicToOpenName, callback) {
 	const { ipcRenderer } = require("electron");
 	var result = ipcRenderer.sendSync("get-quiz", previousQuizId);

--- a/src/dialogs/exit-dialog.html
+++ b/src/dialogs/exit-dialog.html
@@ -70,6 +70,7 @@
 		window.onload = function () {
 			var options = ipcRenderer.sendSync("openDialog", "");
 			var params = JSON.parse(options);
+			document.getElementById("window-title-text").innerHTML = params.title || document.getElementById("window-title-text").innerHTML;
 			document.getElementById("label").innerHTML = params.label;
 			document.getElementById("yes-btn").innerHTML = params.yes;
 			document.getElementById("no-btn").innerHTML = params.no;

--- a/src/dialogs/quiz-dialog.html
+++ b/src/dialogs/quiz-dialog.html
@@ -71,6 +71,7 @@
 		window.onload = function () {
 			var options = ipcRenderer.sendSync("openDialog", "");
 			var params = JSON.parse(options);
+			document.getElementById("window-title-text").innerHTML = params.title || document.getElementById("window-title-text").innerHTML;
 			document.getElementById("label").innerHTML = params.label;
 			document.getElementById("yes-btn").innerHTML = params.yes;
 			document.getElementById("no-btn").innerHTML = params.no;

--- a/src/home-accordi.html
+++ b/src/home-accordi.html
@@ -3,17 +3,25 @@
 
 <head>
 	<title>Accordi</title>
-	<link rel="icon" href="./assets/icon.ico" />
-	<link href="./assets/css/style.css" rel="stylesheet" />
+	<link rel="icon"
+		  href="./assets/icon.ico" />
+	<link href="./assets/css/style.css"
+		  rel="stylesheet" />
 	<!-- FontAwesome -->
-	<link href="./assets/css/fontawesome/css/all.min.css" rel="stylesheet" />
+	<link href="./assets/css/fontawesome/css/all.min.css"
+		  rel="stylesheet" />
 
 	<meta charset="UTF-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<meta name="description" content="StrumentalMente - Dove la musica diventa semplice." />
-	<meta name="keywords" content="StrumentalMente, strumentale, musica, mente, strumenti, imparare, alessi, trollip, multimedia" />
-	<meta name="author" content="FSC" />
-	<meta name="robots" content="index, follow">
+	<meta name="viewport"
+		  content="width=device-width, initial-scale=1.0" />
+	<meta name="description"
+		  content="StrumentalMente - Dove la musica diventa semplice." />
+	<meta name="keywords"
+		  content="StrumentalMente, strumentale, musica, mente, strumenti, imparare, alessi, trollip, multimedia" />
+	<meta name="author"
+		  content="FSC" />
+	<meta name="robots"
+		  content="index, follow">
 </head>
 
 <body>
@@ -21,21 +29,31 @@
 		<div id="titlebar">
 			<div id="drag-region">
 				<div id="window-title">
-					<img id="window-title-image" src="./assets/icon.ico" alt="Icona" />
+					<img id="window-title-image"
+						 src="./assets/icon.ico"
+						 alt="Icona" />
 					<span id="window-title-text">Accordi</span>
 				</div>
 				<div id="window-controls">
-					<div class="button" id="min-button">
-						<span><i class="fas fa-minus" style="font-size: 1.2em;"></i></span>
+					<div class="button"
+						 id="min-button">
+						<span><i class="fas fa-minus"
+							   style="font-size: 1.2em;"></i></span>
 					</div>
-					<div class="button" id="max-button">
-						<span><i class="far fa-window-maximize" style="font-size: 1.2em;"></i></span>
+					<div class="button"
+						 id="max-button">
+						<span><i class="far fa-window-maximize"
+							   style="font-size: 1.2em;"></i></span>
 					</div>
-					<div class="button" id="restore-button">
-						<span><i class="far fa-window-restore" style="font-size: 1.2em;"></i></span>
+					<div class="button"
+						 id="restore-button">
+						<span><i class="far fa-window-restore"
+							   style="font-size: 1.2em;"></i></span>
 					</div>
-					<div class="button" id="close-button">
-						<span><i class="fas fa-times" style="font-size: 1.2em;"></i></span>
+					<div class="button"
+						 id="close-button">
+						<span><i class="fas fa-times"
+							   style="font-size: 1.2em;"></i></span>
 					</div>
 				</div>
 			</div>
@@ -44,52 +62,75 @@
 
 
 	<div class="main-wrapper">
-		<nav class="main-navigation" id="main-nav">
+		<nav class="main-navigation"
+			 id="main-nav">
 			<ul>
 				<li class="logo">
 					<a href="./home.html">
-						<img src="./assets/icon.ico" width="" height="" alt="" />
+						<img src="./assets/icon.ico"
+							 width=""
+							 height=""
+							 alt="" />
 						<h1>Strumental<wbr /><span>Mente</span></h1>
 					</a>
 				</li>
 				<li><a href="./home.html"><i class="fas fa-home"></i> Home</a></li>
-				<li><a href="./profile.html" title="Mostra il profilo dell'utente (Alt+P)"><i class="fas fa-user-circle"></i> Profilo</a></li>
+				<li><a href="./profile.html"
+					   title="Mostra il profilo dell'utente (Alt+P)"><i class="fas fa-user-circle"></i> Profilo</a></li>
 				<li class="dropdown">
-				<li><a href="./home-teoria.html" title="Apri la lista degli argomenti (Alt+T)"><i class="fas fa-book"></i> Teoria</a></li>
-				<li><a href="./home-strumenti.html" title="Apri la lista di srumenti (Alt+S S)"><i class="fas fa-guitar"></i>
+				<li><a href="./home-teoria.html"
+					   title="Apri la lista degli argomenti (Alt+T)"><i class="fas fa-book"></i> Teoria</a></li>
+				<li><a href="./home-strumenti.html"
+					   title="Apri la lista di srumenti (Alt+S S)"><i class="fas fa-guitar"></i>
 						Strumenti</a></li>
-				<li><a title="Apri la lista di strumenti per vederne gli accordi (Alt+A A)" class="active" href="#"><i class="fas fa-music"></i> Accordi</a></li>
+				<li><a title="Apri la lista di strumenti per vederne gli accordi (Alt+A A)"
+					   class="active"
+					   href="#"><i class="fas fa-music"></i> Accordi</a></li>
 				<li>
-					<button type="button" onclick="openModal('./map.html');" title="Mostra la mappa (Alt+M)">
+					<button type="button"
+							onclick="openModal('./map.html');"
+							title="Mostra la mappa (Alt+M)">
 						<i class="fas fa-map"></i> Mappa
 					</button>
 				</li>
 				<li>
-					<button type="button" onclick="openModal('./helpers/help-accordi.html');" title="Mostra l'aiuto (F1)">
+					<button type="button"
+							onclick="openModal('./helpers/help-accordi.html');"
+							title="Mostra l'aiuto (F1)">
 						<i class="fas fa-question"></i> Aiuto
 					</button>
 				</li>
 				<li>
-					<button type="button" onclick="openModal('./about.html');" title="Informazioni (Alt+I)">
+					<button type="button"
+							onclick="openModal('./about.html');"
+							title="Informazioni (Alt+I)">
 						&nbsp;<i class="fas fa-info"></i> Informazioni
 					</button>
 				</li>
 				<li>
-					<button type="button" onclick="showExitDialog();" title="Esci dall'app (Esc)">
+					<button type="button"
+							onclick="showExitDialog();"
+							title="Esci dall'app (Esc)">
 						<i class="fas fa-sign-out-alt"></i> Esci
 					</button>
 				</li>
 			</ul>
 
 			<footer>
-				<p>Copyright &copy; 2019, <a class="external" onclick="openInBrowser('https:\/\/f-s-c.github.io\/');" href="javascript:void(0);">FSC</a>.
+				<p>Copyright &copy; 2019, <a class="external"
+					   onclick="openInBrowser('https:\/\/f-s-c.github.io\/');"
+					   href="javascript:void(0);">FSC</a>.
 					Rilasciato sotto la
-					licenza <a class="external" onclick="openInBrowser('https:\/\/www.apache.org\/licenses\/LICENSE-2.0');" href="javascript:void(0);">Apache
+					licenza <a class="external"
+					   onclick="openInBrowser('https:\/\/www.apache.org\/licenses\/LICENSE-2.0');"
+					   href="javascript:void(0);">Apache
 						2.0</a>.</p>
 				<img src="./assets/images/fsc-logo-svg.svg" />
 			</footer>
 		</nav>
-		<button type="button" id="sidebar-controller" onclick="openMobileNavigation();">
+		<button type="button"
+				id="sidebar-controller"
+				onclick="openMobileNavigation();">
 			<i class="fas fa-bars"></i>
 		</button>
 
@@ -109,49 +150,57 @@
 				</p>
 				<p>È necessario imparare a suonare insieme tutte le note di ogni accordo di tre, quattro o cinque suoni.</p>
 
-
-
-
-				<div class="row topic-buttons" style="grid-template-columns: 32% 32% 32%;">
-					<div class="card-horizontal-alt" style="grid-column: 1; grid-row: 1;">
+				<div class="row topic-buttons"
+					 style="grid-template-columns: 32% 32% 32%;">
+					<button class="card-horizontal-alt"
+							style="grid-column: 1; grid-row: 1;"
+							onclick="warnIfIncomplete('piano', 'teoria del pianoforte', 'agli accordi del pianoforte', () => { window.location.href='./accordi-piano.html'; });"
+							title="Apri gli accordi del pianoforte (Alt+A P)">
 						<div class="card-stacked">
 							<div class="card-content">
 								<img src="./assets/images/piano11.jpg" />
 							</div>
 							<div class="card-action">
-								<a class="btn-text" href="./accordi-piano.html" title="Apri gli accordi del pianoforte (Alt+A P)">Accordi del pianoforte</a>
+								<span class="btn-text">Accordi del pianoforte</span>
 							</div>
 						</div>
-					</div>
-					<div class="card-horizontal-alt" style="grid-column: 2; grid-row: 1;">
+					</button>
+					<button class="card-horizontal-alt"
+							style="grid-column: 2; grid-row: 1;"
+							onclick="warnIfIncomplete('chitarra', 'teoria della chitarra', 'agli accordi della chitarra', () => { window.location.href='./accordi-chitarra.html'; });"
+							title="Apri gli accordi della chitarra (Alt+A C)">
 						<div class="card-stacked">
 							<div class="card-content">
 								<img src="./assets/images/chitarra11.jpg">
 							</div>
 							<div class="card-action">
-								<a class="btn-text" href="./accordi-chitarra.html" title="Apri gli accordi della chitarra (Alt+A C)">Accordi della chitarra</a>
+								<span class="btn-text">Accordi della chitarra</span>
 							</div>
 						</div>
-					</div>
+					</button>
 
-					<div class="card-horizontal-alt" style="grid-column: 3; grid-row: 1;">
-
+					<button class="card-horizontal-alt"
+							style="grid-column: 3; grid-row: 1;"
+							onclick="warnIfIncomplete('basso', 'teoria del basso', 'agli accordi del basso', () => { window.location.href='./accordi-basso.html'; });"
+							title="Apri gli accordi del basso (Alt+A B)">
 						<div class="card-stacked">
 							<div class="card-content">
 								<img src="./assets/images/basso11.jpg">
 							</div>
 							<div class="card-action">
-								<a class="btn-text" href="./accordi-basso.html" title="Apri gli accordi del basso (Alt+A B)">Accordi del basso</a>
+								<span class="btn-text">Accordi del basso</span>
 							</div>
 						</div>
-					</div>
+					</button>
 				</div>
 			</section>
 		</div>
 	</div>
 
-	<script type="text/javascript" src="./assets/js/main.js"></script>
-	<script type="text/javascript" src="./assets/js/render.js"></script>
+	<script type="text/javascript"
+			src="./assets/js/main.js"></script>
+	<script type="text/javascript"
+			src="./assets/js/render.js"></script>
 	<script>
 		openOnKeyboardShortcut("F1", "./helpers/help-accordi.html", true);
 	</script>

--- a/src/home-strumenti.html
+++ b/src/home-strumenti.html
@@ -3,17 +3,25 @@
 
 <head>
 	<title>Strumenti</title>
-	<link rel="icon" href="./assets/icon.ico" />
-	<link href="./assets/css/style.css" rel="stylesheet" />
+	<link rel="icon"
+		  href="./assets/icon.ico" />
+	<link href="./assets/css/style.css"
+		  rel="stylesheet" />
 	<!-- FontAwesome -->
-	<link href="./assets/css/fontawesome/css/all.min.css" rel="stylesheet" />
+	<link href="./assets/css/fontawesome/css/all.min.css"
+		  rel="stylesheet" />
 
 	<meta charset="UTF-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<meta name="description" content="StrumentalMente - Dove la musica diventa semplice." />
-	<meta name="keywords" content="StrumentalMente, strumentale, musica, mente, strumenti, imparare, alessi, trollip, multimedia" />
-	<meta name="author" content="FSC" />
-	<meta name="robots" content="index, follow">
+	<meta name="viewport"
+		  content="width=device-width, initial-scale=1.0" />
+	<meta name="description"
+		  content="StrumentalMente - Dove la musica diventa semplice." />
+	<meta name="keywords"
+		  content="StrumentalMente, strumentale, musica, mente, strumenti, imparare, alessi, trollip, multimedia" />
+	<meta name="author"
+		  content="FSC" />
+	<meta name="robots"
+		  content="index, follow">
 </head>
 
 <body onload="initialize('argomenti', 'teoria/base/');">
@@ -21,21 +29,31 @@
 		<div id="titlebar">
 			<div id="drag-region">
 				<div id="window-title">
-					<img id="window-title-image" src="./assets/icon.ico" alt="Icona" />
+					<img id="window-title-image"
+						 src="./assets/icon.ico"
+						 alt="Icona" />
 					<span id="window-title-text">Teoria base</span>
 				</div>
 				<div id="window-controls">
-					<div class="button" id="min-button">
-						<span><i class="fas fa-minus" style="font-size: 1.2em;"></i></span>
+					<div class="button"
+						 id="min-button">
+						<span><i class="fas fa-minus"
+							   style="font-size: 1.2em;"></i></span>
 					</div>
-					<div class="button" id="max-button">
-						<span><i class="far fa-window-maximize" style="font-size: 1.2em;"></i></span>
+					<div class="button"
+						 id="max-button">
+						<span><i class="far fa-window-maximize"
+							   style="font-size: 1.2em;"></i></span>
 					</div>
-					<div class="button" id="restore-button">
-						<span><i class="far fa-window-restore" style="font-size: 1.2em;"></i></span>
+					<div class="button"
+						 id="restore-button">
+						<span><i class="far fa-window-restore"
+							   style="font-size: 1.2em;"></i></span>
 					</div>
-					<div class="button" id="close-button">
-						<span><i class="fas fa-times" style="font-size: 1.2em;"></i></span>
+					<div class="button"
+						 id="close-button">
+						<span><i class="fas fa-times"
+							   style="font-size: 1.2em;"></i></span>
 					</div>
 				</div>
 			</div>
@@ -44,51 +62,74 @@
 
 
 	<div class="main-wrapper">
-		<nav class="main-navigation" id="main-nav">
+		<nav class="main-navigation"
+			 id="main-nav">
 			<ul>
 				<li class="logo">
 					<a href="./home.html">
-						<img src="./assets/icon.ico" width="" height="" alt="" />
+						<img src="./assets/icon.ico"
+							 width=""
+							 height=""
+							 alt="" />
 						<h1>Strumental<wbr /><span>Mente</span></h1>
 					</a>
 				</li>
 				<li><a href="./home.html"><i class="fas fa-home"></i> Home</a></li>
-				<li><a href="./profile.html" title="Mostra il profilo dell'utente (Alt+P)"><i class="fas fa-user-circle"></i> Profilo</a></li>
-				<li><a href="./home-teoria.html" title="Apri la lista degli argomenti (Alt+T)"><i class="fas fa-book"></i> Teoria</a></li>
-				<li><a class="active" href="#" title="Apri la lista di srumenti (Alt+S S)"><i class="fas fa-guitar"></i> Strumenti</a></li>
-				<li><a title="Apri la lista di strumenti per vederne gli accordi (Alt+A A)" href="./home-accordi.html"><i class="fas fa-music"></i> Accordi</a></li>
+				<li><a href="./profile.html"
+					   title="Mostra il profilo dell'utente (Alt+P)"><i class="fas fa-user-circle"></i> Profilo</a></li>
+				<li><a href="./home-teoria.html"
+					   title="Apri la lista degli argomenti (Alt+T)"><i class="fas fa-book"></i> Teoria</a></li>
+				<li><a class="active"
+					   href="#"
+					   title="Apri la lista di srumenti (Alt+S S)"><i class="fas fa-guitar"></i> Strumenti</a></li>
+				<li><a title="Apri la lista di strumenti per vederne gli accordi (Alt+A A)"
+					   href="./home-accordi.html"><i class="fas fa-music"></i> Accordi</a></li>
 
 				<li>
-					<button type="button" onclick="openModal('./map.html');" title="Mostra la mappa (Alt+M)">
+					<button type="button"
+							onclick="openModal('./map.html');"
+							title="Mostra la mappa (Alt+M)">
 						<i class="fas fa-map"></i> Mappa
 					</button>
 				</li>
 				<li>
-					<button type="button" onclick="openModal('./helpers/help-strumenti.html');" title="Mostra l'aiuto (F1)">
+					<button type="button"
+							onclick="openModal('./helpers/help-strumenti.html');"
+							title="Mostra l'aiuto (F1)">
 						<i class="fas fa-question"></i> Aiuto
 					</button>
 				</li>
 				<li>
-					<button type="button" onclick="openModal('./about.html');" title="Informazioni (Alt+I)">
+					<button type="button"
+							onclick="openModal('./about.html');"
+							title="Informazioni (Alt+I)">
 						&nbsp;<i class="fas fa-info"></i> Informazioni
 					</button>
 				</li>
 				<li>
-					<button type="button" onclick="showExitDialog();" title="Esci dall'app (Esc)">
+					<button type="button"
+							onclick="showExitDialog();"
+							title="Esci dall'app (Esc)">
 						<i class="fas fa-sign-out-alt"></i> Esci
 					</button>
 				</li>
 			</ul>
 
 			<footer>
-				<p>Copyright &copy; 2019, <a class="external" onclick="openInBrowser('https:\/\/f-s-c.github.io\/');" href="javascript:void(0);">FSC</a>.
+				<p>Copyright &copy; 2019, <a class="external"
+					   onclick="openInBrowser('https:\/\/f-s-c.github.io\/');"
+					   href="javascript:void(0);">FSC</a>.
 					Rilasciato sotto la
-					licenza <a class="external" onclick="openInBrowser('https:\/\/www.apache.org\/licenses\/LICENSE-2.0');" href="javascript:void(0);">Apache
+					licenza <a class="external"
+					   onclick="openInBrowser('https:\/\/www.apache.org\/licenses\/LICENSE-2.0');"
+					   href="javascript:void(0);">Apache
 						2.0</a>.</p>
 				<img src="./assets/images/fsc-logo-svg.svg" />
 			</footer>
 		</nav>
-		<button type="button" id="sidebar-controller" onclick="openMobileNavigation();">
+		<button type="button"
+				id="sidebar-controller"
+				onclick="openMobileNavigation();">
 			<i class="fas fa-bars"></i>
 		</button>
 
@@ -118,54 +159,69 @@
 						</ul>
 					</li>
 				</ol>
-				<div class="row topic-buttons" style="grid-template-columns: 24% 24% 24% 24%;">
-					<div class="card-horizontal-alt" style="grid-column: 1; grid-row: 1;">
+				<div class="row topic-buttons"
+					 style="grid-template-columns: 24% 24% 24% 24%;">
+					<button class="card-horizontal-alt"
+							title="Apri la teoria del pianoforte (Alt+S P)"
+							onclick="warnIfIncomplete('base', 'teoria base', 'agli strumenti', () => { window.location.href='./teoria-piano.html'; });"
+							style="grid-column: 1; grid-row: 1;">
 						<div class="card-stacked">
 							<div class="card-content">
 								<img src="./assets/images/piano11.jpg" />
 							</div>
 							<div class="card-action">
-								<a class="btn-text" href="./teoria-piano.html" title="Apri la teoria del pianoforte (Alt+S P)">Vai al pianoforte</a>
+								<span class="btn-text">Vai al pianoforte</span>
 							</div>
 						</div>
-					</div>
-					<div class="card-horizontal-alt" style="grid-column: 2; grid-row: 1;">
+					</button>
+					<button class="card-horizontal-alt"
+							title="Apri la teoria della chitarra (Alt+S C)"
+							onclick="warnIfIncomplete('base', 'teoria base', 'agli strumenti', () => { window.location.href='./teoria-chitarra.html'; });"
+							style="grid-column: 2; grid-row: 1;">
 						<div class="card-stacked">
 							<div class="card-content">
 								<img src="./assets/images/chitarra11.jpg" />
 							</div>
 							<div class="card-action">
-								<a class="btn-text" href="./teoria-chitarra.html" title="Apri la teoria della chitarra (Alt+S C)">Vai alla chitarra</a>
+								<span class="btn-text">Vai alla chitarra</span>
 							</div>
 						</div>
-					</div>
-					<div class="card-horizontal-alt" style="grid-column: 3; grid-row: 1;">
+					</button>
+					<button class="card-horizontal-alt"
+							title="Apri la teoria del basso (Alt+S Shift+B)"
+							onclick="warnIfIncomplete('base', 'teoria base', 'agli strumenti', () => { window.location.href='./teoria-basso.html'; });"
+							style="grid-column: 3; grid-row: 1;">
 						<div class="card-stacked">
 							<div class="card-content">
 								<img src="./assets/images/basso11.jpg" />
 							</div>
 							<div class="card-action">
-								<a class="btn-text" href="./teoria-basso.html" title="Apri la teoria del basso (Alt+S Shift+B)">Vai al basso</a>
+								<span class="btn-text">Vai al basso</span>
 							</div>
 						</div>
-					</div>
-					<div class="card-horizontal-alt" style="grid-column: 4; grid-row: 1;">
+					</button>
+					<button class="card-horizontal-alt"
+							title="Apri la teoria della batteria (Alt+S B)"
+							onclick="warnIfIncomplete('base', 'teoria base', 'agli strumenti', () => { window.location.href='./teoria-batteria.html'; });"
+							style="grid-column: 4; grid-row: 1;">
 						<div class="card-stacked">
 							<div class="card-content">
 								<img src="./assets/images/adult-band-concert-995301.jpg" />
 							</div>
 							<div class="card-action">
-								<a class="btn-text" href="./teoria-batteria.html" title="Apri la teoria della batteria (Alt+S B)">Vai alla batteria</a>
+								<span class="btn-text">Vai alla batteria</span>
 							</div>
 						</div>
-					</div>
+					</button>
 				</div>
 			</section>
 		</div>
 	</div>
 
-	<script type="text/javascript" src="./assets/js/main.js"></script>
-	<script type="text/javascript" src="./assets/js/render.js"></script>
+	<script type="text/javascript"
+			src="./assets/js/main.js"></script>
+	<script type="text/javascript"
+			src="./assets/js/render.js"></script>
 	<script>
 		openOnKeyboardShortcut("F1", "./helpers/help-strumenti.html", true);
 	</script>

--- a/src/home.html
+++ b/src/home.html
@@ -3,18 +3,26 @@
 
 <head>
 	<title>Home - StrumentalMente</title>
-	<link rel="icon" href="./assets/icon.ico" />
+	<link rel="icon"
+		  href="./assets/icon.ico" />
 
-	<link href="./assets/css/style.css" rel="stylesheet" />
+	<link href="./assets/css/style.css"
+		  rel="stylesheet" />
 	<!-- FontAwesome -->
-	<link href="./assets/css/fontawesome/css/all.min.css" rel="stylesheet" />
+	<link href="./assets/css/fontawesome/css/all.min.css"
+		  rel="stylesheet" />
 
 	<meta charset="UTF-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<meta name="description" content="StrumentalMente - Dove la musica diventa semplice." />
-	<meta name="keywords" content="StrumentalMente, strumentale, musica, mente, strumenti, imparare, alessi, trollip, multimedia" />
-	<meta name="author" content="FSC" />
-	<meta name="robots" content="index, follow">
+	<meta name="viewport"
+		  content="width=device-width, initial-scale=1.0" />
+	<meta name="description"
+		  content="StrumentalMente - Dove la musica diventa semplice." />
+	<meta name="keywords"
+		  content="StrumentalMente, strumentale, musica, mente, strumenti, imparare, alessi, trollip, multimedia" />
+	<meta name="author"
+		  content="FSC" />
+	<meta name="robots"
+		  content="index, follow">
 </head>
 
 <body>
@@ -22,21 +30,31 @@
 		<div id="titlebar">
 			<div id="drag-region">
 				<div id="window-title">
-					<img id="window-title-image" src="./assets/icon.ico" alt="Icona" />
+					<img id="window-title-image"
+						 src="./assets/icon.ico"
+						 alt="Icona" />
 					<span id="window-title-text">Home - StrumentalMente</span>
 				</div>
 				<div id="window-controls">
-					<div class="button" id="min-button">
-						<span><i class="fas fa-minus" style="font-size: 1.2em;"></i></span>
+					<div class="button"
+						 id="min-button">
+						<span><i class="fas fa-minus"
+							   style="font-size: 1.2em;"></i></span>
 					</div>
-					<div class="button" id="max-button">
-						<span><i class="far fa-window-maximize" style="font-size: 1.2em;"></i></span>
+					<div class="button"
+						 id="max-button">
+						<span><i class="far fa-window-maximize"
+							   style="font-size: 1.2em;"></i></span>
 					</div>
-					<div class="button" id="restore-button">
-						<span><i class="far fa-window-restore" style="font-size: 1.2em;"></i></span>
+					<div class="button"
+						 id="restore-button">
+						<span><i class="far fa-window-restore"
+							   style="font-size: 1.2em;"></i></span>
 					</div>
-					<div class="button" id="close-button">
-						<span><i class="fas fa-times" style="font-size: 1.2em;"></i></span>
+					<div class="button"
+						 id="close-button">
+						<span><i class="fas fa-times"
+							   style="font-size: 1.2em;"></i></span>
 					</div>
 				</div>
 			</div>
@@ -45,50 +63,71 @@
 
 
 	<div class="main-wrapper">
-		<nav class="main-navigation" id="main-nav">
+		<nav class="main-navigation"
+			 id="main-nav">
 			<ul>
 				<li class="logo">
 					<a href="#">
-						<img src="./assets/icon.ico" width="" height="" alt="" />
+						<img src="./assets/icon.ico"
+							 width=""
+							 height=""
+							 alt="" />
 						<h1>Strumental<wbr /><span>Mente</span></h1>
 					</a>
 				</li>
-				<li><a class="active" href="#"><i class="fas fa-home"></i> Home</a></li>
-				<li><a href="./profile.html" title="Mostra il profilo dell'utente (Alt+P)"><i class="fas fa-user-circle"></i> Profilo</a></li>
-				<li><a href="./home-teoria.html" title="Apri la lista degli argomenti (Alt+T)"><i class="fas fa-book"></i> Teoria</a></li>
-				<li><a href="./home-strumenti.html" title="Apri la lista di strumenti (Alt+S S)"><i class="fas fa-guitar"></i> Strumenti</a></li>
-				<li><a title="Apri la lista di strumenti per vederne gli accordi (Alt+A A)" href="./home-accordi.html"><i class="fas fa-music"></i> Accordi</a></li>
+				<li><a class="active"
+					   href="#"><i class="fas fa-home"></i> Home</a></li>
+				<li><a href="./profile.html"
+					   title="Mostra il profilo dell'utente (Alt+P)"><i class="fas fa-user-circle"></i> Profilo</a></li>
+				<li><a href="./home-teoria.html"
+					   title="Apri la lista degli argomenti (Alt+T)"><i class="fas fa-book"></i> Teoria</a></li>
+				<li><a href="./home-strumenti.html"
+					   title="Apri la lista di strumenti (Alt+S S)"><i class="fas fa-guitar"></i> Strumenti</a></li>
+				<li><a title="Apri la lista di strumenti per vederne gli accordi (Alt+A A)"
+					   href="./home-accordi.html"><i class="fas fa-music"></i> Accordi</a></li>
 				<li>
-					<button type="button" onclick="openModal('./map.html');" title="Mostra la mappa (Alt+M)">
+					<button type="button"
+							onclick="openModal('./map.html');"
+							title="Mostra la mappa (Alt+M)">
 						<i class="fas fa-map"></i> Mappa
 					</button>
 				</li>
 				<li>
-					<button type="button" onclick="openModal('./helpers/help-home.html');" title="Mostra l'aiuto (F1)">
+					<button type="button"
+							onclick="openModal('./helpers/help-home.html');"
+							title="Mostra l'aiuto (F1)">
 						<i class="fas fa-question"></i> Aiuto
 					</button>
 				</li>
 				<li>
-					<button type="button" onclick="openModal('./about.html');" title="Informazioni  (Alt+I)">
+					<button type="button"
+							onclick="openModal('./about.html');"
+							title="Informazioni  (Alt+I)">
 						&nbsp;<i class="fas fa-info"></i> Informazioni
 					</button>
 				</li>
 				<li>
-					<button type="button" onclick="showExitDialog();" title="Esci dall'app (Esc)">
+					<button type="button"
+							onclick="showExitDialog();"
+							title="Esci dall'app (Esc)">
 						<i class="fas fa-sign-out-alt"></i> Esci
 					</button>
 				</li>
 			</ul>
 
 			<footer>
-				<p>Copyright &copy; 2019, <a onclick="openInBrowser('https:\/\/f-s-c.github.io\/');" href="javascript:void(0);">FSC</a>.
+				<p>Copyright &copy; 2019, <a onclick="openInBrowser('https:\/\/f-s-c.github.io\/');"
+					   href="javascript:void(0);">FSC</a>.
 					Rilasciato sotto la
-					licenza <a onclick="openInBrowser('https:\/\/www.apache.org\/licenses\/LICENSE-2.0');" href="javascript:void(0);">Apache
+					licenza <a onclick="openInBrowser('https:\/\/www.apache.org\/licenses\/LICENSE-2.0');"
+					   href="javascript:void(0);">Apache
 						2.0</a>.</p>
 				<img src="./assets/images/fsc-logo-svg.svg" />
 			</footer>
 		</nav>
-		<button type="button" id="sidebar-controller" onclick="openMobileNavigation();">
+		<button type="button"
+				id="sidebar-controller"
+				onclick="openMobileNavigation();">
 			<i class="fas fa-bars"></i>
 		</button>
 
@@ -96,16 +135,22 @@
 			<article>
 				<header>
 					<div class="blind-audio-buttons">
-						<button type="button" onclick="playStopAudio('blind-audio', this, 'stop-blind-audio');" class="btn-audio btn-accessibility">
+						<button type="button"
+								onclick="playStopAudio('blind-audio', this, 'stop-blind-audio');"
+								class="btn-audio btn-accessibility">
 							<i class="fas fa-universal-access"></i>
 						</button>
-						<button type="button" id="stop-blind-audio" class="btn-audio audio-reload" style="display: none;">
+						<button type="button"
+								id="stop-blind-audio"
+								class="btn-audio audio-reload"
+								style="display: none;">
 							<i class="fas fa-undo"></i>
 						</button>
 					</div>
 					<h1>Un'introduzione alla musica</h1>
 					<h2>La dolce arte che rallegra i nostri giorni</h2>
-					<audio id="blind-audio" src="./assets/audios/readings/teoria-base.wav"></audio>
+					<audio id="blind-audio"
+						   src="./assets/audios/readings/teoria-base.wav"></audio>
 					<hr />
 				</header>
 				<section>
@@ -128,37 +173,47 @@
 						"facilità o difficoltà" nell'apprendimento. Si seguano solo le proprie passioni, quando si saranno
 						palesate. Ovviamente l'approcciarsi con lo strumento scelto richiede necessariamente, come primo
 						passo, un approccio alla teoria di base della musica.</p>
-					<div class="row topic-buttons" style="grid-template-columns: calc(33% - 16px) calc(33% - 16px) calc(33% - 16px);">
-						<div class="card-horizontal-alt" style="grid-column: 1; grid-row: 1;">
+					<div class="row topic-buttons"
+						 style="grid-template-columns: calc(33% - 16px) calc(33% - 16px) calc(33% - 16px);">
+						<a class="card-horizontal-alt"
+						   title="Apri la sezione teoria (Alt+T)"
+						   href="./home-teoria.html"
+						   style="grid-column: 1; grid-row: 1;">
 							<div class="card-stacked">
 								<div class="card-content">
 									<img src="./assets/images/note.jpg" />
 								</div>
 								<div class="card-action">
-									<a class="btn-text" href="./home-teoria.html" title="Apri la sezione teoria (Alt+T)">La teoria</a>
+									<span class="btn-text">La teoria</span>
 								</div>
 							</div>
-						</div>
-						<div class="card-horizontal-alt" style="grid-column: 2; grid-row: 1;">
+						</a>
+						<a class="card-horizontal-alt"
+						   href="./home-strumenti.html"
+						   title="Apri la sezione strumenti (Alt+S S)"
+						   style="grid-column: 2; grid-row: 1;">
 							<div class="card-stacked">
 								<div class="card-content">
 									<img src="./assets/images/guitar.jpg">
 								</div>
 								<div class="card-action">
-									<a class="btn-text" href="./home-strumenti.html" title="Apri la sezione strumenti (Alt+S S)">Gli strumenti</a>
+									<span class="btn-text">Gli strumenti</span>
 								</div>
 							</div>
-						</div>
-						<div class="card-horizontal-alt" style="grid-column: 3; grid-row: 1;">
+						</a>
+						<a class="card-horizontal-alt"
+						   href="./home-accordi.html"
+						   title="Apri la sezione accordi (Alt+A A)"
+						   style="grid-column: 3; grid-row: 1;">
 							<div class="card-stacked">
 								<div class="card-content">
 									<img src="./assets/images/accordi.jpg">
 								</div>
 								<div class="card-action">
-									<a class="btn-text" href="./home-accordi.html" title="Apri la sezione accordi (Alt+A A)">Gli accordi</a>
+									<span class="btn-text">Gli accordi</span>
 								</div>
 							</div>
-						</div>
+						</a>
 					</div>
 				</section>
 			</article>

--- a/src/teoria/argomenti.html
+++ b/src/teoria/argomenti.html
@@ -3,18 +3,27 @@
 
 <head>
 	<title>Teoria musicale</title>
-	<link rel="icon" href="../assets/icon.ico" />
-	<link href="../assets/css/main/section.css" rel="stylesheet" />
-	<link href="../assets/css/style.css" rel="stylesheet" />
+	<link rel="icon"
+		  href="../assets/icon.ico" />
+	<link href="../assets/css/main/section.css"
+		  rel="stylesheet" />
+	<link href="../assets/css/style.css"
+		  rel="stylesheet" />
 	<!-- FontAwesome -->
-	<link href="../assets/css/fontawesome/css/all.min.css" rel="stylesheet" />
+	<link href="../assets/css/fontawesome/css/all.min.css"
+		  rel="stylesheet" />
 
 	<meta charset="UTF-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<meta name="description" content="StrumentalMente - Dove la musica diventa semplice." />
-	<meta name="keywords" content="StrumentalMente, strumentale, musica, mente, strumenti, imparare, alessi, trollip, multimedia" />
-	<meta name="author" content="FSC" />
-	<meta name="robots" content="index, follow">
+	<meta name="viewport"
+		  content="width=device-width, initial-scale=1.0" />
+	<meta name="description"
+		  content="StrumentalMente - Dove la musica diventa semplice." />
+	<meta name="keywords"
+		  content="StrumentalMente, strumentale, musica, mente, strumenti, imparare, alessi, trollip, multimedia" />
+	<meta name="author"
+		  content="FSC" />
+	<meta name="robots"
+		  content="index, follow">
 </head>
 
 <body onload="window.parent.setLinks(1, { previous: '', previousLink: '', next: 'Il suono', nextLink: 'base/suono' });">
@@ -27,7 +36,9 @@
 						<h2>Tutto ciò che serve per poter poi suonare uno strumento</h2>
 						<div class="breadcrumbs-container">
 							<div class="breadcrumbs">
-								<button type="button" class="breadcrumb" onclick="window.parent.location.href = '../home-teoria.html';">Teoria</button>
+								<button type="button"
+										class="breadcrumb"
+										onclick="window.parent.location.href = '../home-teoria.html';">Teoria</button>
 								<span class="breadcrumb">Indice (pag. <span id="current-topic-slide">1</span> di <span id="max-topic-slides">1</span>)</span>
 							</div>
 							<div class="page-container">
@@ -36,59 +47,96 @@
 						</div>
 						<hr />
 					</header>
-					<div class="topic-row" style="grid-template-columns: calc(50% - 8px) calc(50% - 8px);">
+					<div class="topic-row"
+						 style="grid-template-columns: calc(50% - 8px) calc(50% - 8px);">
 						<div class="topic-level">
-							<button type="button" class="btn-text card-topic" onclick="showSubButtons(this, 'basic');">
+							<button type="button"
+									class="btn-text card-topic"
+									onclick="showSubButtons(this, 'basic');">
 								<h3><span>Teoria base</span></h3>
 							</button>
-							<div class="topic-level-container" id="basic" style="display: none;">
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./suono', './teoria/base/');">
+							<div class="topic-level-container"
+								 id="basic"
+								 style="display: none;">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./suono', './teoria/base/');">
 									<span>Il suono</span>
 								</button>
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./note', './teoria/base/');">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./note', './teoria/base/');">
 									<span>Le note</span>
 								</button>
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./rigo', './teoria/base/');">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./rigo', './teoria/base/');">
 									<span>Il rigo</span>
 								</button>
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./chiavi', './teoria/base/');">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./chiavi', './teoria/base/');">
 									<span>Le chiavi</span>
 								</button>
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./valori-e-pause', './teoria/base/');">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./valori-e-pause', './teoria/base/');">
 									<span>Valori e pause</span>
 								</button>
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./ritmo', './teoria/base/');">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./ritmo', './teoria/base/');">
 									<span>Il ritmo</span>
 								</button>
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./tempo', './teoria/base/');">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./tempo', './teoria/base/');">
 									<span>Il tempo</span>
 								</button>
 							</div>
 						</div>
 						<div class="topic-level">
-							<button type="button" class="btn-text card-topic" onclick="showSubButtons(this, 'advanced');">
+							<button type="button"
+									class="btn-text card-topic"
+									onclick="window.parent.warnIfIncomplete('base', 'teoria base', 'alla teoria avanzata', () => { showSubButtons(this, 'advanced'); });">
 								<h3><span>Teoria avanzata</span></h3>
 							</button>
-							<div class="topic-level-container" id="advanced" style="display: none;">
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic( './tono-e-semitono', './teoria/avanzata/');">
+							<div class="topic-level-container"
+								 id="advanced"
+								 style="display: none;">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic( './tono-e-semitono', './teoria/avanzata/');">
 									<span>Tono e semitono</span>
 								</button>
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./alterazioni', './teoria/avanzata/');">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./alterazioni', './teoria/avanzata/');">
 									<span>Alterazioni</span>
 								</button>
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./do-maggiore-la-minore', './teoria/avanzata/');">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./do-maggiore-la-minore', './teoria/avanzata/');">
 									<span>Do maggiore e La minore</span>
 								</button>
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./intervalli', './teoria/avanzata/');">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./intervalli', './teoria/avanzata/');">
 									<span>Intervalli</span>
 								</button>
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./tono-semitono-diatonico-e-cromatico', './teoria/avanzata/');">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./tono-semitono-diatonico-e-cromatico', './teoria/avanzata/');">
 									<span>Tono-semitono diatonico e cromatico</span>
 								</button>
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./tonalita-e-modo', './teoria/avanzata/');">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./tonalita-e-modo', './teoria/avanzata/');">
 									<span>La tonalità e il modo</span>
 								</button>
-								<button type="button" class="btn-text card-topic" onclick="window.parent.changeTopic('./accordo-tonale', './teoria/avanzata/');">
+								<button type="button"
+										class="btn-text card-topic"
+										onclick="window.parent.changeTopic('./accordo-tonale', './teoria/avanzata/');">
 									<span>Accordo tonale</span>
 								</button>
 							</div>
@@ -99,8 +147,10 @@
 		</div>
 	</div>
 
-	<script type="text/javascript" src="../assets/js/main.js"></script>
-	<script type="text/javascript" src="../assets/js/render.js"></script>
+	<script type="text/javascript"
+			src="../assets/js/main.js"></script>
+	<script type="text/javascript"
+			src="../assets/js/render.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Aggiunti dei dialoghi che saranno mostrati se è richiesto un argomento _"avanzato"_ senza il previo superamento degli argomenti _"propedeutici"_. Tali dialoghi, tuttavia, consentono (come prestabilito) di proseguire nell'argomento avanzato scelto.

Lo schema di aperture dei dialoghi (come concordato) è basato sulle seguenti relazioni tra argomenti e quiz propedeutici:

|Argomento richiesto|Quiz propedeutico|
|:---------------------:|:--------------------:|
|Teoria base|*Nessuno*|
|Teoria avanzata|Teoria base|
|Teoria del pianoforte|Teoria base|
|Teoria della chitarra|Teoria base|
|Teoria del basso|Teoria base|
|Teoria della batteria|Teoria base|
|Accordi del pianoforte|Teoria del pianoforte|
|Accordi del basso|Teoria del basso|
|Accordi della chitarra|Teoria della chitarra|